### PR TITLE
make sure to init heading info for pdf files

### DIFF
--- a/src/analyze/text_analyzer.py
+++ b/src/analyze/text_analyzer.py
@@ -103,6 +103,7 @@ class TextAnalyzer:
         # Extract text based on file type
         if file_type == 'pdf':
             text, page_count = self._extract_from_pdf(file_path)
+            heading_info = None
         elif file_type == 'docx':
             text, page_count, heading_info = self._extract_from_docx(file_path)
         else:  # txt


### PR DESCRIPTION
## 📝 Description

Fixed an `UnboundLocalError` that occurred when analyzing PDF files. The bug was caused by the `heading_info` variable not being initialized in the PDF extraction branch, while it was being accessed later when building the [TextMetrics](cci:2://file:///Users/kaidenmerchant/Desktop/School/Year%204/Term%201/capstone-project-team-14/src/analyze/text_analyzer.py:22:0-57:27) object.

**Root Cause:**
- When processing PDF files, the code extracted `text` and `page_count` but never set `heading_info = None`
- TXT and DOCX branches properly initialized `heading_info`, but PDF branch was missing this initialization
- This caused a crash when trying to access `heading_info.get('heading_count')` on line 137

**Fix:**
- Added `heading_info = None` after PDF extraction (line 106)
- PDFs don't have structured headings like DOCX files, so `None` is the correct value

**Closes:** https://github.com/COSC-499-W2025/capstone-project-team-14/issues/95

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

**Manual Testing:**
```bash
# Previously failed with UnboundLocalError
python3 src/analyze/analyze_text.py path/to/example.pdf

# Now works correctly and returns metrics dictionary