### PR TITLE
code & tests for uploading user thumbnail

### DIFF
--- a/src/projects/__init__.py
+++ b/src/projects/__init__.py
@@ -1,0 +1,1 @@
+from .api import router

--- a/src/projects/api.py
+++ b/src/projects/api.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, UploadFile, File, HTTPException
+from fastapi.responses import HTMLResponse, JSONResponse
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+@router.get("/{project_name}/thumbnail", response_class=HTMLResponse)
+async def get_thumbnail_form(project_name: str):
+    return (
+        """
+        <html>
+          <head><title>Upload Thumbnail</title></head>
+          <body>
+            <h1>Upload thumbnail for project</h1>
+            <form action="" method="post" enctype="multipart/form-data">
+              <input type="file" name="file" accept="image/png,image/jpeg,image/webp" />
+              <button type="submit">Upload</button>
+            </form>
+          </body>
+        </html>
+        """
+    )
+
+
+MAX_BYTES = 5 * 1024 * 1024
+ALLOWED_TYPES = {"image/png", "image/jpeg", "image/webp"}
+
+
+@router.post("/{project_name}/thumbnail")
+async def upload_thumbnail(project_name: str, file: UploadFile = File(...)):
+    if file.content_type not in ALLOWED_TYPES:
+        raise HTTPException(status_code=400, detail="Invalid file type. Use PNG, JPEG, or WebP.")
+
+    data = await file.read()
+    size = len(data)
+    if size > MAX_BYTES:
+        raise HTTPException(status_code=400, detail="File too large. Max 5 MB.")
+
+    return JSONResponse(
+        {
+            "status": "ok",
+            "project": project_name,
+            "filename": file.filename,
+            "content_type": file.content_type,
+            "size": size,
+        }
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/projects/test_thumbnail_upload.py
+++ b/tests/projects/test_thumbnail_upload.py
@@ -1,0 +1,62 @@
+import os
+import httpx
+import inspect
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.projects.api import router
+
+
+if "app" not in inspect.signature(httpx.Client.__init__).parameters:
+    _orig_httpx_init = httpx.Client.__init__
+
+    def _patched_httpx_init(self, *args, **kwargs):
+        kwargs.pop("app", None)
+        return _orig_httpx_init(self, *args, **kwargs)
+
+    httpx.Client.__init__ = _patched_httpx_init
+
+
+def _mk_app():
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+def test_get_thumbnail_form_renders():
+    client = TestClient(_mk_app())
+    resp = client.get("/projects/demo/thumbnail")
+    assert resp.status_code == 200
+    text = resp.text.lower()
+    assert "<form" in text and "type=\"file\"" in text
+
+
+def test_upload_thumbnail_png_success():
+    client = TestClient(_mk_app())
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"0" * 128
+    files = {"file": ("thumb.png", png_bytes, "image/png")}
+    resp = client.post("/projects/demo/thumbnail", files=files)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["project"] == "demo"
+    assert body["filename"] == "thumb.png"
+    assert body["content_type"] == "image/png"
+    assert body["size"] == len(png_bytes)
+
+
+def test_upload_thumbnail_rejects_invalid_type():
+    client = TestClient(_mk_app())
+    files = {"file": ("note.txt", b"hello", "text/plain")}
+    resp = client.post("/projects/demo/thumbnail", files=files)
+    assert resp.status_code == 400
+    assert "Invalid file type" in resp.text
+
+
+def test_upload_thumbnail_rejects_large_file():
+    client = TestClient(_mk_app())
+    big = b"0" * (5 * 1024 * 1024 + 1)
+    files = {"file": ("big.jpg", big, "image/jpeg")}
+    resp = client.post("/projects/demo/thumbnail", files=files)
+    assert resp.status_code == 400
+    assert "File too large" in resp.text


### PR DESCRIPTION

## 📝 Description

This PR adds a new thumbnail upload endpoint for projects using FastAPI. It introduces a router that serves a simple HTML upload form and a POST endpoint that accepts image uploads, validates file type and size, and returns metadata about the uploaded file.

This enables projects to accept thumbnails in a controlled and testable way, providing a foundation for later adding storage (local or S3) and database integration.



**Closes:** #184 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

This change was tested using automated pytest tests and FastAPI’s `TestClient`.

The tests spin up a minimal FastAPI app, include the new router, and verify:
- The upload form renders correctly
- Valid image uploads succeed
- Invalid file types are rejected
- Files larger than 5 MB are rejected

To run the tests:

```bash
pytest -q tests/projects/test_thumbnail_upload.py

