### PR TITLE
Portfolio project showcase Customization

### DIFF
--- a/src/insights/api.py
+++ b/src/insights/api.py
@@ -1,12 +1,13 @@
 """
-FastAPI router exposing insights deletion endpoints.
+FastAPI router exposing insights endpoints (deletion and customization).
 """
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, List, Dict, Any
 import os
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, validator
 
 from .storage import ProjectInsightsStore, DEFAULT_DB_PATH
 
@@ -41,3 +42,64 @@ def delete_project_insight(zip_hash: str, project_name: str, store: ProjectInsig
     if counts["deleted_projects"] == 0:
         raise HTTPException(status_code=404, detail="project not found")
     return {"status": "ok", **counts}
+
+
+class PortfolioCustomizationPayload(BaseModel):
+    portfolio_fields: Optional[Dict[str, Any]] = Field(default=None)
+    resume_bullets: Optional[List[str]] = Field(default=None)
+
+    @validator("resume_bullets")
+    def _validate_bullets(cls, v):  # type: ignore[override]
+        if v is None:
+            return v
+        if not isinstance(v, list):
+            raise ValueError("resume_bullets must be a list of strings")
+        cleaned = []
+        for b in v:
+            if not isinstance(b, str):
+                raise ValueError("All resume bullets must be strings")
+            s = b.strip()
+            if s:
+                cleaned.append(s)
+        if len(cleaned) == 0:
+            raise ValueError("resume_bullets must contain at least one non-empty string")
+        return cleaned
+
+
+@router.patch("/portfolio/{project_info_id}")
+def patch_portfolio_customization(
+    project_info_id: int,
+    payload: PortfolioCustomizationPayload,
+    store: ProjectInsightsStore = Depends(get_store),
+):
+    # Ensure project exists
+    existing = store.load_project_insight_by_id(project_info_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="project_info_id not found")
+
+    # Allow only known portfolio fields
+    allowed: Dict[str, Any] = {}
+    if payload.portfolio_fields:
+        for k in [
+            "tagline",
+            "description",
+            "project_type",
+            "complexity",
+            "is_collaborative",
+            "summary",
+            "key_features",
+        ]:
+            if k in payload.portfolio_fields:
+                allowed[k] = payload.portfolio_fields[k]
+
+    changed = store.save_portfolio_customization(
+        project_info_id,
+        portfolio_fields=allowed if allowed else None,
+        resume_bullets=payload.resume_bullets,
+    )
+    if not changed:
+        # Nothing to update
+        return {"status": "noop", "project_info_id": project_info_id}
+
+    updated = store.load_project_insight_by_id(project_info_id)
+    return {"status": "ok", "project_info_id": project_info_id, "portfolio_item": updated.get("portfolio_item"), "resume_item": updated.get("resume_item")}

--- a/src/insights/storage.py
+++ b/src/insights/storage.py
@@ -566,6 +566,145 @@ class ProjectInsightsStore:
             metadata_updated=metadata_updated,
         )
 
+    # Customization API
+    def update_portfolio_insights_fields(
+        self,
+        project_info_id: int,
+        fields: Dict[str, Any],
+    ) -> bool:
+        """
+        Update editable fields for a portfolio insight row identified by project_info_id.
+
+        Editable keys: tagline, description, project_type, complexity, is_collaborative,
+        summary, key_features (list -> stored as JSON).
+
+        Returns True if a row was updated.
+        """
+        editable = {
+            "tagline",
+            "description",
+            "project_type",
+            "complexity",
+            "is_collaborative",
+            "summary",
+            "key_features",
+        }
+        update_data: Dict[str, Any] = {}
+        for k, v in (fields or {}).items():
+            if k in editable:
+                update_data[k] = v
+        if not update_data:
+            return False
+
+        with self._lock:
+            with self._connect() as conn:
+                row = conn.execute(
+                    f"SELECT id FROM {PORTFOLIO_INSIGHTS_TABLE} WHERE project_info_id = ?;",
+                    (project_info_id,),
+                ).fetchone()
+                if not row:
+                    return False
+                sets = []
+                params: List[Any] = []
+                if "tagline" in update_data:
+                    sets.append("tagline = ?")
+                    params.append(update_data["tagline"])
+                if "description" in update_data:
+                    sets.append("description = ?")
+                    params.append(update_data["description"])
+                if "project_type" in update_data:
+                    sets.append("project_type = ?")
+                    params.append(update_data["project_type"])
+                if "complexity" in update_data:
+                    sets.append("complexity = ?")
+                    params.append(update_data["complexity"])
+                if "is_collaborative" in update_data:
+                    sets.append("is_collaborative = ?")
+                    params.append(1 if update_data["is_collaborative"] else 0)
+                if "summary" in update_data:
+                    sets.append("summary = ?")
+                    params.append(update_data["summary"])
+                if "key_features" in update_data:
+                    sets.append("key_features_json = ?")
+                    try:
+                        params.append(json.dumps(update_data["key_features"] or []))
+                    except Exception:
+                        params.append("[]")
+                if not sets:
+                    return False
+                params.append(project_info_id)
+                conn.execute(
+                    f"UPDATE {PORTFOLIO_INSIGHTS_TABLE} SET " + ", ".join(sets) + " WHERE project_info_id = ?;",
+                    tuple(params),
+                )
+                return True
+
+    def replace_resume_bullets(
+        self,
+        project_info_id: int,
+        bullets: List[str],
+    ) -> bool:
+        """
+        Replace resume bullets for a given project_info_id. All existing bullets are removed
+        and replaced with the provided list as manual, selected bullets in display order.
+
+        Returns True if replacement occurred (portfolio insight row existed).
+        """
+        # Normalize bullets
+        cleaned: List[str] = []
+        for b in bullets or []:
+            if isinstance(b, str):
+                s = b.strip()
+                if s:
+                    cleaned.append(s)
+
+        with self._lock:
+            with self._connect() as conn:
+                insight_row = conn.execute(
+                    f"SELECT id FROM {PORTFOLIO_INSIGHTS_TABLE} WHERE project_info_id = ?;",
+                    (project_info_id,),
+                ).fetchone()
+                if not insight_row:
+                    return False
+                insight_id = insight_row[0]
+                conn.isolation_level = None
+                conn.execute("BEGIN IMMEDIATE;")
+                try:
+                    conn.execute(
+                        f"DELETE FROM {RESUME_BULLETS_TABLE} WHERE portfolio_insight_id = ?;",
+                        (insight_id,),
+                    )
+                    for order, text in enumerate(cleaned):
+                        conn.execute(
+                            f"""
+                            INSERT INTO {RESUME_BULLETS_TABLE} (portfolio_insight_id, bullet_text, display_order, is_selected, source)
+                            VALUES (?, ?, ?, ?, ?);
+                            """,
+                            (insight_id, text, order, 1, "manual"),
+                        )
+                    conn.execute("COMMIT;")
+                except Exception:
+                    conn.execute("ROLLBACK;")
+                    raise
+                return True
+
+    def save_portfolio_customization(
+        self,
+        project_info_id: int,
+        portfolio_fields: Optional[Dict[str, Any]] = None,
+        resume_bullets: Optional[List[str]] = None,
+    ) -> bool:
+        """
+        Convenience method to update portfolio fields and/or replace resume bullets.
+        Returns True if at least one change was applied.
+        """
+        changed = False
+        if portfolio_fields:
+            changed = self.update_portfolio_insights_fields(project_info_id, portfolio_fields) or changed
+        if resume_bullets is not None:
+            changed = self.replace_resume_bullets(project_info_id, resume_bullets) or changed
+        return changed
+
     def load_project_insight(self, zip_hash: str, project_name: str) -> Optional[Dict[str, Any]]:
         with self._connect() as conn:
             ingest_id = self._latest_ingest_id(conn, zip_hash)

--- a/tests/insights/test_portfolio_customization.py
+++ b/tests/insights/test_portfolio_customization.py
@@ -1,0 +1,109 @@
+import os
+import tempfile
+import sqlite3
+from typing import Dict, Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.insights.storage import ProjectInsightsStore
+from src.insights.api import router
+
+
+def _mk_store(tmpdir: str) -> ProjectInsightsStore:
+    db_path = os.path.join(tmpdir, "app.db")
+    return ProjectInsightsStore(db_path=db_path, encryption_key=b"dev")
+
+
+def _insert_run_with_portfolio(store: ProjectInsightsStore, zip_path: str) -> None:
+    payload: Dict[str, Any] = {
+        "zip_metadata": {
+            "root_name": os.path.basename(zip_path),
+            "file_count": 1,
+            "total_uncompressed_bytes": 10,
+            "total_compressed_bytes": 5,
+        },
+        "projects": {
+            "demo": {
+                "categorized_contents": {"code": ["a.py"]},
+                "portfolio_item": {
+                    "tagline": "Initial Tagline",
+                    "description": "Initial Description",
+                    "project_type": "web",
+                    "complexity": "medium",
+                    "is_collaborative": False,
+                    "summary": "Initial Summary",
+                    "key_features": ["Feature A", "Feature B"],
+                },
+                "resume_item": {
+                    "project_name": "demo",
+                    "bullets": ["Did X", "Built Y"],
+                },
+            }
+        },
+    }
+    stats = store.record_pipeline_run(zip_path, payload)
+    assert stats.inserted == 1
+
+
+def _get_any_project_info_id(db_path: str) -> int:
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute("SELECT id FROM project_info ORDER BY id DESC LIMIT 1;").fetchone()
+        assert row is not None
+        return int(row[0])
+
+
+def test_patch_portfolio_customization_updates_fields_and_bullets():
+    with tempfile.TemporaryDirectory() as td:
+        store = _mk_store(td)
+        _insert_run_with_portfolio(store, os.path.join(td, "z1.zip"))
+        pid = _get_any_project_info_id(store.db_path)
+
+        # Build API app
+        os.environ["DATABASE_URL"] = f"sqlite:///{store.db_path}"
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        # Patch customization
+        resp = client.patch(
+            f"/insights/portfolio/{pid}",
+            json={
+                "portfolio_fields": {
+                    "tagline": "New Tagline",
+                    "description": "Refined Description",
+                    "key_features": ["Improved A", "Added B"],
+                    "is_collaborative": True,
+                },
+                "resume_bullets": ["Led migration", "Optimized pipeline"],
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] in ("ok", "noop")
+
+        # Load back from store and verify
+        updated = store.load_project_insight_by_id(pid)
+        assert updated is not None
+        p = updated["portfolio_item"]
+        r = updated["resume_item"]
+        assert p["tagline"] == "New Tagline"
+        assert p["description"] == "Refined Description"
+        assert p["is_collaborative"] is True
+        assert p["key_features"] == ["Improved A", "Added B"]
+        assert r["bullets"] == ["Led migration", "Optimized pipeline"]
+
+
+def test_patch_portfolio_customization_404_for_unknown_id():
+    with tempfile.TemporaryDirectory() as td:
+        store = _mk_store(td)
+        os.environ["DATABASE_URL"] = f"sqlite:///{store.db_path}"
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        resp = client.patch(
+            "/insights/portfolio/999999",
+            json={"portfolio_fields": {"tagline": "T"}, "resume_bullets": ["A"]},
+        )
+        assert resp.status_code == 404


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR adds persistent portfolio customization support to the Insights service.

It introduces a storage layer for updating editable portfolio insight fields and replacing resume bullets, along with a PATCH API endpoint to apply these changes atomically. Editable portfolio fields (such as tagline, description, project metadata, and key features) are selectively updated using a whitelist, while resume bullets are fully replaced in display order to reflect manual user selection.

The implementation respects the existing schema, uses database transactions for consistency, and is fully covered by tests that validate both successful updates and error cases.

**Closes:** #211 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

This PR was tested using automated pytest coverage.

- Seeded a project with an initial portfolio item and resume bullets
- Sent a PATCH request to update both portfolio fields and resume bullets
- Verified persisted updates via `load_project_insight_by_id`
- Verified `404` response for unknown `project_info_id`
- Confirmed router compatibility by running deletion tests

### Commands run:
```bash
pytest -q tests/insights/test_portfolio_customization.py
pytest -q tests/insights/test_deletion.py


