### PR TITLE
Data Access Consent Re-Prompt and Analyzer/Test Alignment

### DIFF
--- a/src/pipeline/orchestrator.py
+++ b/src/pipeline/orchestrator.py
@@ -15,7 +15,7 @@ from datetime import datetime
 
 from src.ingest.zip_parser import parse_zip
 from src.categorize.file_categorizer import categorize_folder_structure
-from src.analyze.text_analyzer import TextAnalyzer
+from src.analyze.text_analyzer import TextAnalyzer, TextMetrics
 from src.analyze.code_analyzer import CodeAnalyzer
 from src.analyze.video_analyzer import VideoAnalyzer
 from src.analyze.advanced_skill_extractor import AdvancedSkillExtractor
@@ -678,7 +678,7 @@ class ArtifactPipeline:
                 
                 # Calculate totals
                 totals = self.text_analyzer._calculate_totals(
-                    [self.text_analyzer.TextMetrics(**r) for r in doc_results]
+                    [TextMetrics(**r) for r in doc_results]
                 )
                 
                 results['documentation'] = {
@@ -1673,9 +1673,22 @@ def resolve_data_access_consent(zip_path: str, user_id: str) -> bool:
     if existing:
         if existing.zip_file != zip_str:
             manager.update_config(user_id, zip_file=zip_str)
-        status = "granted" if existing.data_access_consent else "denied"
-        print(f"\n🔐 Using stored data access consent for user '{user_id}': {status}")
-        return existing.data_access_consent
+            existing.zip_file = zip_str
+        if existing.data_access_consent:
+            print(f"\n🔐 Using stored data access consent for user '{user_id}': granted")
+            return True
+        print(f"\n🔐 Data access consent for user '{user_id}' was not previously provided.")
+        consent = _prompt_for_data_access_consent()
+        stored = manager.update_config(
+            user_id,
+            zip_file=existing.zip_file,
+            data_access_consent=consent,
+        )
+        if not stored:
+            print("⚠️  Unable to persist consent choice; proceeding with this selection for the current run.")
+        else:
+            print(f"✅ Saved data access consent for user '{user_id}' to local configuration.")
+        return consent
 
     consent = _prompt_for_data_access_consent()
     stored = manager.create_config(

--- a/tests/pipeline/test_llm_consent_flow.py
+++ b/tests/pipeline/test_llm_consent_flow.py
@@ -131,6 +131,49 @@ def test_resolve_llm_consent_prompts_and_saves(monkeypatch, temp_db, tmp_path):
     assert cfg.zip_file == str(zip_path)
 
 
+def test_resolve_data_access_consent_prompts_and_saves(monkeypatch, temp_db, tmp_path):
+    responses = iter(["y"])
+    monkeypatch.setattr("builtins.input", lambda _: next(responses))
+
+    zip_path = tmp_path / "data.zip"
+    zip_path.write_text("placeholder zip path marker")
+
+    consent = orchestrator.resolve_data_access_consent(str(zip_path), "fresh-user")
+    assert consent is True
+
+    cfg = config_manager.UserConfigManager(db_path=temp_db).load_config("fresh-user")
+    assert cfg is not None
+    assert cfg.data_access_consent is True
+    assert cfg.llm_consent is False
+    assert cfg.llm_consent_asked is False
+    assert cfg.zip_file == str(zip_path)
+
+
+def test_resolve_data_access_consent_reprompts_after_denial(monkeypatch, temp_db, tmp_path):
+    manager = config_manager.UserConfigManager(db_path=temp_db)
+    manager.create_config(
+        "tester",
+        "/tmp/original.zip",
+        llm_consent=False,
+        llm_consent_asked=False,
+        data_access_consent=False,
+    )
+
+    prompts = []
+    monkeypatch.setattr("builtins.input", lambda _: prompts.append(True) or "y")
+
+    zip_path = tmp_path / "latest.zip"
+    zip_path.write_text("placeholder zip path marker")
+
+    consent = orchestrator.resolve_data_access_consent(str(zip_path), "tester")
+    assert consent is True
+    assert len(prompts) == 1
+
+    cfg = manager.load_config("tester")
+    assert cfg.data_access_consent is True
+    assert cfg.zip_file == str(zip_path)
+
+
 def test_pipeline_runs_llm_when_enabled(monkeypatch, tmp_path):
     zip_path = _create_test_zip(tmp_path)
 

--- a/tests/pipeline/test_orchestrator_coverage.py
+++ b/tests/pipeline/test_orchestrator_coverage.py
@@ -140,7 +140,38 @@ def test_process_project_local_only(monkeypatch, tmp_path):
         def to_dict(self):
             return self.__dict__
 
-    pipeline.text_analyzer.analyze_batch = lambda files: {"files": [], "totals": {"total_files": len(files), "total_words": 1}}
+    from src.analyze.text_analyzer import TextMetrics
+
+    class StubTextAnalyzer:
+        def analyze_file(self, file_path):
+            return TextMetrics(
+                file_path=str(file_path),
+                file_name=Path(file_path).name,
+                file_type="txt",
+                file_size_bytes=1,
+                created_time="now",
+                modified_time="now",
+                page_count=None,
+                word_count=1,
+                sentence_count=1,
+                paragraph_count=1,
+                character_count=1,
+                estimated_reading_time_minutes=0.01,
+                lexical_diversity=1.0,
+                avg_word_length=1.0,
+                avg_sentence_length=1.0,
+                top_keywords=[("test", 1)],
+                heading_count=None,
+                heading_breakdown=None,
+            )
+
+        def _calculate_totals(self, results):
+            return {
+                "total_files": len(results),
+                "total_words": sum(r.word_count for r in results),
+            }
+
+    pipeline.text_analyzer = StubTextAnalyzer()
     pipeline.image_processor.batch_analyze = lambda files: []
     pipeline.code_analyzer.analyze_file = lambda f: StubAnalysisResult()
     pipeline.code_analyzer.calculate_contribution_metrics = lambda results: types.SimpleNamespace(
@@ -304,12 +335,45 @@ def test_analyze_categorized_files_all_paths(monkeypatch):
     pipeline = orchestrator.ArtifactPipeline(enable_insights=False)
 
     class StubTextAnalyzer:
-        def analyze_batch(self, files):
-            return {"files": [], "totals": {"total_files": len(files), "total_words": 10}}
+        def analyze_file(self, file_path):
+            from src.analyze.text_analyzer import TextMetrics
+
+            return TextMetrics(
+                file_path=str(file_path),
+                file_name=Path(file_path).name,
+                file_type="txt",
+                file_size_bytes=1,
+                created_time="now",
+                modified_time="now",
+                page_count=None,
+                word_count=10,
+                sentence_count=1,
+                paragraph_count=1,
+                character_count=10,
+                estimated_reading_time_minutes=0.05,
+                lexical_diversity=1.0,
+                avg_word_length=1.0,
+                avg_sentence_length=1.0,
+                top_keywords=[("test", 1)],
+                heading_count=None,
+                heading_breakdown=None,
+            )
+
+        def _calculate_totals(self, results):
+            return {
+                "total_files": len(results),
+                "total_words": sum(r.word_count for r in results),
+            }
 
     class StubImageProcessor:
-        def batch_analyze(self, files):
-            return [{"file_name": Path(f).name, "file_stats": {"size_mb": 1}, "resolution": {"width": 1, "height": 1}, "format": {"format": "png"}, "content_classification": {"primary_type": "image"}} for f in files]
+        def analyze_image(self, file_path):
+            return {
+                "file_name": Path(file_path).name,
+                "file_stats": {"size_mb": 1},
+                "resolution": {"width": 1, "height": 1},
+                "format": {"format": "png"},
+                "content_classification": {"primary_type": "image"},
+            }
 
     class StubCodeAnalyzer:
         def analyze_file(self, f):


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

The data access consent flow now re-prompts users who previously denied consent instead of exiting immediately. If consent is granted on the re-prompt, the stored configuration is updated and the zip path is synchronized. Also, documentation analysis totals are fixed by building TextMetrics directly, preventing missing totals in _analyze_categorized_files. New tests cover first-time data access consent persistence and re-prompt-after-denial behavior. Lastly, the LLM consent reuse test was restored to ensure stored consent skips the prompt. Test stubs in test_orchestrator_coverage.py were aligned with the current analyzer APIs so totals and image analyses behave as expected.

**Closes:** #222

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [x] ⚡ Performance improvement

---

## 🧪 Testing

Run the following commands:

1) Ensure Docker is running, then build and start the backend once:
```bash
docker compose build backend
docker compose up -d backend
```

2) Run the demo ZIP and decline prompts for local-only analysis:
```bash
docker compose run --rm backend python -m src.pipeline.orchestrator tests/categorize/demo_projects.zip
```

3) Run the demo ZIP and decline prompts for local-only analysis again:
```bash
docker compose run --rm backend python -m src.pipeline.orchestrator tests/categorize/demo_projects.zip
```

4) Run the demo ZIP and allow prompts for local-only analysis:
```bash
docker compose run --rm backend python -m src.pipeline.orchestrator tests/categorize/demo_projects.zip
```

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
