### PR TITLE
Fixed Insight/Configuration Deletion

### DIFF
--- a/src/pipeline/cli.py
+++ b/src/pipeline/cli.py
@@ -5,6 +5,7 @@ import os
 import json
 import getpass
 import argparse
+import sqlite3
 from typing import Optional, List, Dict, Any
 
 
@@ -153,6 +154,57 @@ def main(argv: Optional[List[str]] = None) -> int:
         action="append",
         help="Filter by framework (can be specified multiple times)"
     )
+
+    delete_parser = subparsers.add_parser(
+        "delete",
+        help="Delete stored insights or user configurations",
+        description=(
+            "Delete stored insights and/or user configurations.\n\n"
+            "Examples:\n"
+            "  python -m src.pipeline delete all\n"
+            "  python -m src.pipeline delete insight --project-id 1\n"
+            "  python -m src.pipeline delete insight all\n"
+            "  python -m src.pipeline delete config all\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    delete_parser.add_argument(
+        "--db-path",
+        help="Path to the database (default: data/app.db)"
+    )
+    delete_subparsers = delete_parser.add_subparsers(dest="delete_target", help="Delete target")
+
+    delete_subparsers.add_parser(
+        "all",
+        help="Delete all insights and user configurations"
+    )
+
+    delete_insight_parser = delete_subparsers.add_parser(
+        "insight",
+        help="Delete insights by project id or delete all insights"
+    )
+    delete_insight_parser.add_argument(
+        "--project-id",
+        type=int,
+        help="Project ID from `list`"
+    )
+    delete_insight_parser.add_argument(
+        "scope",
+        nargs="?",
+        choices=["all"],
+        help="Delete all insights"
+    )
+
+    delete_config_parser = delete_subparsers.add_parser(
+        "config",
+        help="Delete all user configurations"
+    )
+    delete_config_parser.add_argument(
+        "scope",
+        nargs="?",
+        choices=["all"],
+        help="Delete all user configurations"
+    )
     
     args = parser.parse_args(argv)
     
@@ -171,6 +223,8 @@ def main(argv: Optional[List[str]] = None) -> int:
             return handle_show_resume(args)
         elif args.command == "list":
             return handle_list(args)
+        elif args.command == "delete":
+            return handle_delete(args)
         else:
             print(f"Unknown command: {args.command}", file=sys.stderr)
             return 1
@@ -383,6 +437,150 @@ def handle_list(args) -> int:
     
     print(f"\n{'='*100}\n")
     return 0
+
+
+def handle_delete(args) -> int:
+    """Handle the 'delete' subcommand."""
+    from src.insights.storage import DEFAULT_DB_PATH, ProjectInsightsStore
+
+    if not args.delete_target:
+        print("Error: Missing delete target. Use 'delete -h' for options.", file=sys.stderr)
+        return 1
+
+    db_path = args.db_path or DEFAULT_DB_PATH
+
+    if args.delete_target == "all":
+        if not confirm_action(
+            "Are you sure you want to delete all insights and user configurations? This cannot be undone."
+        ):
+            print("Cancelled.")
+            return 0
+        insights_store = ProjectInsightsStore(db_path=db_path)
+        insights_counts = insights_store.delete_all()
+        configs_deleted = delete_user_configurations_all(db_path)
+        print(f"Deleted projects: {insights_counts.get('deleted_projects', 0)}")
+        print(f"Deleted user configurations: {configs_deleted}")
+        return 0
+
+    if args.delete_target == "insight":
+        if args.project_id and args.scope:
+            print("Error: Use either --project-id or 'all' for delete insight.", file=sys.stderr)
+            return 1
+        if not args.project_id and args.scope != "all":
+            print("Error: Provide --project-id or 'all' for delete insight.", file=sys.stderr)
+            return 1
+
+        if args.scope == "all":
+            if not confirm_action(
+                "Are you sure you want to delete all insights? This cannot be undone."
+            ):
+                print("Cancelled.")
+                return 0
+            insights_store = ProjectInsightsStore(db_path=db_path)
+            insights_counts = insights_store.delete_all()
+            print(f"Deleted projects: {insights_counts.get('deleted_projects', 0)}")
+            print(f"Deleted zips: {insights_counts.get('deleted_zips', 0)}")
+            return 0
+
+        if not confirm_action(
+            f"Are you sure you want to delete insights for project id {args.project_id}? This cannot be undone."
+        ):
+            print("Cancelled.")
+            return 0
+        insights_counts = delete_insights_for_project_id(db_path, args.project_id)
+        print(f"Deleted projects: {insights_counts.get('deleted_projects', 0)}")
+        print(f"Deleted zips: {insights_counts.get('deleted_zips', 0)}")
+        return 0
+
+    if args.delete_target == "config":
+        if args.scope != "all":
+            print("Error: Use 'all' for delete config.", file=sys.stderr)
+            return 1
+        if not confirm_action(
+            "Are you sure you want to delete all user configurations? This cannot be undone."
+        ):
+            print("Cancelled.")
+            return 0
+        configs_deleted = delete_user_configurations_all(db_path)
+        print(f"Deleted user configurations: {configs_deleted}")
+        return 0
+
+    print(f"Unknown delete target: {args.delete_target}", file=sys.stderr)
+    return 1
+
+
+def confirm_action(prompt: str) -> bool:
+    """Prompt user for confirmation before destructive actions."""
+    try:
+        response = input(f"{prompt} [y/N]: ").strip().lower()
+    except EOFError:
+        return False
+    return response in {"y", "yes"}
+
+
+def delete_user_configurations_all(db_path: str) -> int:
+    """Delete all rows in user_configurations. Returns number of deleted rows."""
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA foreign_keys=ON;")
+        if not table_exists(conn, "user_configurations"):
+            return 0
+        conn.execute("DELETE FROM user_configurations;")
+        conn.commit()
+        return conn.execute("SELECT changes();").fetchone()[0]
+
+
+def delete_insights_for_project_id(db_path: str, project_info_id: int) -> Dict[str, int]:
+    """Delete insights for a single project_info id. Returns counts."""
+    from src.insights.storage import PROJECT_INFO_TABLE, PROJECTS_TABLE, INGEST_TABLE
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("PRAGMA foreign_keys=ON;")
+        if not table_exists(conn, PROJECT_INFO_TABLE):
+            return {"deleted_projects": 0, "deleted_zips": 0}
+        conn.isolation_level = None
+        conn.execute("BEGIN IMMEDIATE;")
+        try:
+            row = conn.execute(
+                f"SELECT project_id, ingest_id FROM {PROJECT_INFO_TABLE} WHERE id = ?;",
+                (project_info_id,),
+            ).fetchone()
+            if not row:
+                conn.execute("ROLLBACK;")
+                return {"deleted_projects": 0, "deleted_zips": 0}
+
+            project_id, ingest_id = row
+            conn.execute(f"DELETE FROM {PROJECT_INFO_TABLE} WHERE id = ?;", (project_info_id,))
+            deleted_projects = conn.execute("SELECT changes();").fetchone()[0]
+
+            remaining_for_project = conn.execute(
+                f"SELECT COUNT(*) FROM {PROJECT_INFO_TABLE} WHERE project_id = ?;",
+                (project_id,),
+            ).fetchone()[0]
+            if remaining_for_project == 0:
+                conn.execute(f"DELETE FROM {PROJECTS_TABLE} WHERE id = ?;", (project_id,))
+
+            remaining_for_ingest = conn.execute(
+                f"SELECT COUNT(*) FROM {PROJECT_INFO_TABLE} WHERE ingest_id = ?;",
+                (ingest_id,),
+            ).fetchone()[0]
+            deleted_zips = 0
+            if remaining_for_ingest == 0:
+                conn.execute(f"DELETE FROM {INGEST_TABLE} WHERE id = ?;", (ingest_id,))
+                deleted_zips = 1
+
+            conn.execute("COMMIT;")
+            return {"deleted_projects": deleted_projects, "deleted_zips": deleted_zips}
+        except Exception:
+            conn.execute("ROLLBACK;")
+            raise
+
+
+def table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?;",
+        (table_name,),
+    ).fetchone()
+    return bool(row)
 
 
 def print_single_result(result) -> None:

--- a/tests/pipeline/test_pipeline_cli.py
+++ b/tests/pipeline/test_pipeline_cli.py
@@ -150,6 +150,114 @@ class TestListCommand:
         assert "No projects found" in captured.out
 
 
+class TestDeleteCommand:
+    """Tests for the 'delete' subcommand"""
+
+    @patch("src.pipeline.cli.confirm_action", return_value=True)
+    @patch("src.pipeline.cli.delete_user_configurations_all", return_value=3)
+    @patch("src.insights.storage.ProjectInsightsStore")
+    def test_delete_all_happy_path(self, mock_store, mock_configs, _confirm, capsys):
+        mock_store.return_value.delete_all.return_value = {"deleted_projects": 5}
+        exit_code = cli.main(["delete", "all"])
+        assert exit_code == 0
+        mock_store.return_value.delete_all.assert_called_once()
+        mock_configs.assert_called_once()
+        captured = capsys.readouterr()
+        assert "Deleted projects: 5" in captured.out
+        assert "Deleted user configurations: 3" in captured.out
+
+    @patch("src.pipeline.cli.confirm_action", return_value=False)
+    def test_delete_cancelled(self, _confirm, capsys):
+        exit_code = cli.main(["delete", "insight", "all"])
+        assert exit_code == 0
+        assert "Cancelled." in capsys.readouterr().out
+
+    @patch("src.pipeline.cli.confirm_action", return_value=True)
+    @patch("src.pipeline.cli.delete_insights_for_project_id", return_value={"deleted_projects": 1, "deleted_zips": 0})
+    def test_delete_insight_by_project_id(self, mock_delete, _confirm):
+        exit_code = cli.main(["delete", "insight", "--project-id", "7"])
+        assert exit_code == 0
+        mock_delete.assert_called_once_with("data/app.db", 7)
+
+    @patch("src.pipeline.cli.confirm_action", return_value=True)
+    @patch("src.insights.storage.ProjectInsightsStore")
+    def test_delete_insight_all(self, mock_store, _confirm, capsys):
+        mock_store.return_value.delete_all.return_value = {"deleted_projects": 4, "deleted_zips": 2}
+        exit_code = cli.main(["delete", "insight", "all"])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "Deleted projects: 4" in captured.out
+        assert "Deleted zips: 2" in captured.out
+
+    @patch("src.pipeline.cli.confirm_action", return_value=True)
+    @patch("src.pipeline.cli.delete_user_configurations_all", return_value=2)
+    def test_delete_config_all(self, _delete_all, _confirm, capsys):
+        exit_code = cli.main(["delete", "config", "all"])
+        assert exit_code == 0
+        assert "Deleted user configurations: 2" in capsys.readouterr().out
+
+    def test_delete_insight_missing_selector(self):
+        exit_code = cli.main(["delete", "insight"])
+        assert exit_code == 1
+
+    def test_delete_insight_invalid_argument_combo(self):
+        exit_code = cli.main(["delete", "insight", "--project-id", "3", "all"])
+        assert exit_code == 1
+
+    def test_delete_config_cancelled(self, capsys):
+        with patch("src.pipeline.cli.confirm_action", return_value=False):
+            exit_code = cli.main(["delete", "config", "all"])
+        assert exit_code == 0
+        assert "Cancelled." in capsys.readouterr().out
+
+    def test_delete_missing_target(self):
+        exit_code = cli.main(["delete"])
+        assert exit_code == 1
+
+    @patch("src.pipeline.cli.confirm_action", return_value=True)
+    def test_delete_config_all_missing_table(self, _confirm, tmp_path, capsys):
+        db_path = tmp_path / "empty.db"
+        exit_code = cli.main(["delete", "--db-path", str(db_path), "config", "all"])
+        assert exit_code == 0
+        assert "Deleted user configurations: 0" in capsys.readouterr().out
+
+    @patch("src.pipeline.cli.confirm_action", return_value=True)
+    def test_delete_insight_project_id_not_found(self, _confirm, tmp_path, capsys):
+        import sqlite3
+
+        db_path = tmp_path / "insights.db"
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("CREATE TABLE project_info (id INTEGER, project_id INTEGER, ingest_id INTEGER);")
+            conn.commit()
+        exit_code = cli.main(["delete", "--db-path", str(db_path), "insight", "--project-id", "42"])
+        assert exit_code == 0
+        output = capsys.readouterr().out
+        assert "Deleted projects: 0" in output
+        assert "Deleted zips: 0" in output
+
+    @patch("src.pipeline.cli.confirm_action", return_value=True)
+    def test_delete_insight_cleans_up_related_rows(self, _confirm, tmp_path):
+        import sqlite3
+
+        db_path = tmp_path / "insights_full.db"
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("CREATE TABLE ingest (id INTEGER PRIMARY KEY);")
+            conn.execute("CREATE TABLE projects (id INTEGER PRIMARY KEY);")
+            conn.execute("CREATE TABLE project_info (id INTEGER, project_id INTEGER, ingest_id INTEGER);")
+            conn.execute("INSERT INTO ingest (id) VALUES (1);")
+            conn.execute("INSERT INTO projects (id) VALUES (10);")
+            conn.execute("INSERT INTO project_info (id, project_id, ingest_id) VALUES (5, 10, 1);")
+            conn.commit()
+
+        exit_code = cli.main(["delete", "--db-path", str(db_path), "insight", "--project-id", "5"])
+        assert exit_code == 0
+
+        with sqlite3.connect(db_path) as conn:
+            assert conn.execute("SELECT COUNT(*) FROM project_info;").fetchone()[0] == 0
+            assert conn.execute("SELECT COUNT(*) FROM projects;").fetchone()[0] == 0
+            assert conn.execute("SELECT COUNT(*) FROM ingest;").fetchone()[0] == 0
+
+
 class TestMainFunction:
     """Tests for main() function behavior"""
     


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

I added a delete command group to cli.py with confirmation prompts and subcommands for delete all, delete insight --project-id <id>, delete insight all, and delete config all. Bulk insight deletion uses ProjectInsightsStore.delete_all(), while per-project insight deletion and config deletion run direct SQLite deletes. I also expanded test_pipeline_cli.py to cover happy paths, cancellations, invalid argument combos, missing selectors, and SQLite-backed edge cases.

**Closes:** #246

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [x] ⚡ Performance improvement

---

## 🧪 Testing

1) Ensure Docker is running, then build and start the backend once:
```bash
docker compose build backend
docker compose up -d backend
```

2) Run the demo ZIP:
```bash
docker compose run --rm backend python -m src.pipeline.orchestrator tests/categorize/demo_projects.zip
```

3) View the projects listed:
```bash
docker compose run --rm backend python -m src.pipeline.orchestrator tests/categorize/demo_projects.zip
```

4) Delete the user configurations saved and one of the projects by project id:
```bash
docker compose run --rm backend python -m src.pipeline delete config all
docker compose run --rm backend python -m src.pipeline delete insight --project-id <id>
```

5) View the projects listed:
```bash
docker compose run --rm backend python -m src.pipeline.orchestrator tests/categorize/demo_projects.zip
```

6) Delete all of the projects and then run an analysis and then run the command to delete all user configs and insights:
```bash
docker compose run --rm backend python -m src.pipeline delete insight all
docker compose run --rm backend python -m src.pipeline.orchestrator tests/categorize/demo_projects.zip
docker compose run --rm backend python -m src.pipeline delete all
```

7) Run the updated test suit:
```bash
docker-compose run --rm backend pytest tests/pipeline/test_pipeline_cli.py -v
```

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
