### PR TITLE
Persist Chronology Overrides On Skills Mutations (PR 1/2)

### DIFF
--- a/src/api/routers/chronological.py
+++ b/src/api/routers/chronological.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -34,6 +34,78 @@ class ChronologicalProjectsResponse(BaseModel):
     """Chronological list of projects."""
     total_projects: int
     projects: List[dict]
+
+
+def _normalized_timeline(events: Any) -> List[Dict[str, Any]]:
+    if not isinstance(events, list):
+        return []
+    normalized: List[Dict[str, Any]] = []
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        timestamp = event.get("timestamp")
+        if not isinstance(timestamp, str) or not timestamp:
+            continue
+        skills_raw = event.get("skills")
+        if not isinstance(skills_raw, list):
+            continue
+        skills = [str(value).strip().casefold() for value in skills_raw if isinstance(value, str) and value.strip()]
+        if not skills:
+            continue
+        metadata = event.get("metadata")
+        normalized.append(
+            {
+                "file": str(event.get("file") or "manual-entry"),
+                "timestamp": timestamp,
+                "category": str(event.get("category") or "manual"),
+                "skills": skills,
+                "metadata": metadata if isinstance(metadata, dict) else {},
+            }
+        )
+    return normalized
+
+
+def _project_chronology_view(raw: Any, project_id: Optional[int]) -> Dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+
+    if isinstance(project_id, int):
+        overrides = raw.get("project_overrides")
+        if isinstance(overrides, dict):
+            override = overrides.get(str(project_id))
+            if isinstance(override, dict):
+                if "timeline" in override:
+                    timeline = _normalized_timeline(override.get("timeline"))
+                    categories = override.get("categories")
+                    if not isinstance(categories, list):
+                        categories = sorted(
+                            {
+                                event.get("category")
+                                for event in timeline
+                                if isinstance(event.get("category"), str)
+                            }
+                        )
+                    total_events = override.get("total_events")
+                    if not isinstance(total_events, int):
+                        total_events = len(timeline)
+                    return {
+                        "timeline": timeline,
+                        "categories": categories,
+                        "total_events": total_events,
+                    }
+
+    timeline = _normalized_timeline(raw.get("timeline"))
+    categories = raw.get("categories")
+    if not isinstance(categories, list):
+        categories = sorted({event.get("category") for event in timeline if isinstance(event.get("category"), str)})
+    total_events = raw.get("total_events")
+    if not isinstance(total_events, int):
+        total_events = len(timeline)
+    return {
+        "timeline": timeline,
+        "categories": categories,
+        "total_events": total_events,
+    }
 
 
 @router.get("/skills", response_model=ChronologicalSkillsResponse)
@@ -77,19 +149,23 @@ def get_chronological_skills(
             status_code=500,
             detail=f"Error loading project insights: {str(e)}"
         )
-    
+
+    if not payload:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    project_id = payload.get("project_id") if isinstance(payload.get("project_id"), int) else None
     global_insights = payload.get("global_insights", {})
-    chron_skills = global_insights.get("chronological_skills", {})
-    
+    chron_skills = _project_chronology_view(
+        global_insights.get("chronological_skills", {}),
+        project_id,
+    )
+
     if not chron_skills or not chron_skills.get("timeline"):
         raise HTTPException(
             status_code=404,
             detail=f"No chronological skills found for project: {project_name}"
         )
-    
-    # Get project_id if available
-    project_id = payload.get("project_id")
-    
+
     return ChronologicalSkillsResponse(
         project_id=project_id,
         project_name=project_name,
@@ -136,8 +212,11 @@ def get_chronological_skills_by_project_id(
     
     # Get chronological skills
     global_insights = payload.get("global_insights", {})
-    chron_skills = global_insights.get("chronological_skills", {})
-    
+    chron_skills = _project_chronology_view(
+        global_insights.get("chronological_skills", {}),
+        project_id,
+    )
+
     if not chron_skills or not chron_skills.get("timeline"):
         raise HTTPException(
             status_code=404,
@@ -225,4 +304,3 @@ def get_chronological_projects(
         total_projects=len(all_projects),
         projects=all_projects
     )
-

--- a/src/api/routers/skills.py
+++ b/src/api/routers/skills.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Set
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from src.api.deps import get_store
 from src.insights.storage import ProjectInsightsStore
@@ -15,6 +16,9 @@ router = APIRouter(prefix="/skills", tags=["skills"])
 class SkillsAddPayload(BaseModel):
     project_id: int
     skills: List[str]
+    month: Optional[int] = Field(None, ge=1, le=12)
+    year: Optional[int] = Field(None, ge=1000, le=9999)
+    timestamp: Optional[str] = None
 
 
 class SkillsRemovePayload(BaseModel):
@@ -27,6 +31,9 @@ class SkillsEditPayload(BaseModel):
     old: Optional[str] = None
     new: Optional[str] = None
     skills: Optional[List[str]] = None
+    month: Optional[int] = Field(None, ge=1, le=12)
+    year: Optional[int] = Field(None, ge=1000, le=9999)
+    timestamp: Optional[str] = None
 
 
 def _normalize_skills(values: List[Any]) -> List[str]:
@@ -41,6 +48,142 @@ def _normalize_skills(values: List[Any]) -> List[str]:
         seen.add(cleaned)
         normalized.append(cleaned)
     return normalized
+
+
+def _resolve_event_timestamp(
+    *,
+    month: Optional[int] = None,
+    year: Optional[int] = None,
+    timestamp: Optional[str] = None,
+) -> str:
+    if timestamp is not None:
+        candidate = str(timestamp).strip()
+        if not candidate:
+            raise HTTPException(status_code=400, detail="'timestamp' must be a non-empty ISO datetime.")
+        try:
+            parsed = datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400,
+                detail="'timestamp' must be an ISO datetime string.",
+            ) from exc
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc).isoformat()
+
+    if (month is None) != (year is None):
+        raise HTTPException(status_code=400, detail="Provide both 'month' and 'year' together.")
+    if month is not None and year is not None:
+        return datetime(year, month, 1, tzinfo=timezone.utc).isoformat()
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_timeline_events(value: Any) -> List[Dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    normalized: List[Dict[str, Any]] = []
+    for entry in value:
+        if not isinstance(entry, dict):
+            continue
+        timestamp = entry.get("timestamp")
+        if not isinstance(timestamp, str) or not timestamp:
+            continue
+        skills = _normalize_skills(entry.get("skills", []) or [])
+        if not skills:
+            continue
+        metadata = entry.get("metadata")
+        normalized.append(
+            {
+                "file": str(entry.get("file") or "manual-entry"),
+                "timestamp": timestamp,
+                "category": str(entry.get("category") or "manual"),
+                "skills": skills,
+                "metadata": metadata if isinstance(metadata, dict) else {},
+            }
+        )
+    return normalized
+
+
+def _project_timeline_for_mutation(project_payload: Dict[str, Any], project_id: int) -> List[Dict[str, Any]]:
+    global_insights = project_payload.get("global_insights") or {}
+    chronology = global_insights.get("chronological_skills") if isinstance(global_insights, dict) else {}
+    if not isinstance(chronology, dict):
+        return []
+    overrides = chronology.get("project_overrides")
+    if isinstance(overrides, dict):
+        override = overrides.get(str(project_id))
+        if isinstance(override, dict):
+            if "timeline" in override:
+                return _normalize_timeline_events(override.get("timeline"))
+    return _normalize_timeline_events(chronology.get("timeline"))
+
+
+def _align_timeline_with_skills(
+    *,
+    existing_timeline: List[Dict[str, Any]],
+    target_skills: List[str],
+    emphasized_skills: Optional[List[str]] = None,
+    event_timestamp: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    normalized_target = _normalize_skills(target_skills)
+    target_set = set(normalized_target)
+    if not target_set:
+        return []
+
+    aligned: List[Dict[str, Any]] = []
+    seen_in_timeline: Set[str] = set()
+    for entry in _normalize_timeline_events(existing_timeline):
+        retained_skills = [skill for skill in entry.get("skills", []) if skill in target_set]
+        if not retained_skills:
+            continue
+        seen_in_timeline.update(retained_skills)
+        aligned.append({**entry, "skills": retained_skills})
+
+    stamp_skills: List[str] = []
+    for skill in _normalize_skills(emphasized_skills or []):
+        if skill in target_set and skill not in stamp_skills:
+            stamp_skills.append(skill)
+    for skill in normalized_target:
+        if skill not in seen_in_timeline and skill not in stamp_skills:
+            stamp_skills.append(skill)
+
+    if stamp_skills:
+        aligned.append(
+            {
+                "file": "manual-entry",
+                "timestamp": event_timestamp or datetime.now(timezone.utc).isoformat(),
+                "category": "manual",
+                "skills": stamp_skills,
+                "metadata": {"source": "skills_api", "type": "mutation"},
+            }
+        )
+    return aligned
+
+
+def _sync_project_chronology(
+    *,
+    project_id: int,
+    updated_skills: List[str],
+    store: ProjectInsightsStore,
+    emphasized_skills: Optional[List[str]] = None,
+    month: Optional[int] = None,
+    year: Optional[int] = None,
+    timestamp: Optional[str] = None,
+) -> None:
+    payload = store.load_project_insight_by_id(project_id)
+    if not payload:
+        return
+    existing_timeline = _project_timeline_for_mutation(payload, project_id)
+    resolved_timestamp: Optional[str] = None
+    if emphasized_skills is not None or month is not None or year is not None or timestamp is not None:
+        resolved_timestamp = _resolve_event_timestamp(month=month, year=year, timestamp=timestamp)
+    updated_timeline = _align_timeline_with_skills(
+        existing_timeline=existing_timeline,
+        target_skills=updated_skills,
+        emphasized_skills=emphasized_skills,
+        event_timestamp=resolved_timestamp,
+    )
+    store.upsert_project_chronology_override(project_id, updated_timeline)
 
 
 def _load_project_skills_or_404(project_id: int, store: ProjectInsightsStore) -> List[str]:
@@ -108,6 +251,15 @@ def add_skills(payload: SkillsAddPayload, store: ProjectInsightsStore = Depends(
     current_skills = _load_project_skills_or_404(payload.project_id, store)
     updated_skills = _normalize_skills(current_skills + payload.skills)
     store.update_project_skills(payload.project_id, updated_skills)
+    _sync_project_chronology(
+        project_id=payload.project_id,
+        updated_skills=updated_skills,
+        store=store,
+        emphasized_skills=payload.skills,
+        month=payload.month,
+        year=payload.year,
+        timestamp=payload.timestamp,
+    )
     return _skills_response(payload.project_id, updated_skills)
 
 
@@ -117,6 +269,11 @@ def remove_skills(payload: SkillsRemovePayload, store: ProjectInsightsStore = De
     to_remove = set(_normalize_skills(payload.skills))
     updated_skills = [skill for skill in current_skills if skill not in to_remove]
     store.update_project_skills(payload.project_id, updated_skills)
+    _sync_project_chronology(
+        project_id=payload.project_id,
+        updated_skills=updated_skills,
+        store=store,
+    )
     return _skills_response(payload.project_id, updated_skills)
 
 
@@ -127,6 +284,15 @@ def edit_skills(payload: SkillsEditPayload, store: ProjectInsightsStore = Depend
     if payload.skills is not None:
         updated_skills = _normalize_skills(payload.skills)
         store.update_project_skills(payload.project_id, updated_skills)
+        _sync_project_chronology(
+            project_id=payload.project_id,
+            updated_skills=updated_skills,
+            store=store,
+            emphasized_skills=updated_skills,
+            month=payload.month,
+            year=payload.year,
+            timestamp=payload.timestamp,
+        )
         return _skills_response(payload.project_id, updated_skills)
 
     if payload.old is None or payload.new is None:
@@ -148,4 +314,13 @@ def edit_skills(payload: SkillsEditPayload, store: ProjectInsightsStore = Depend
     replaced = [new_skill if skill == old_skill else skill for skill in current_skills]
     updated_skills = _normalize_skills(replaced)
     store.update_project_skills(payload.project_id, updated_skills)
+    _sync_project_chronology(
+        project_id=payload.project_id,
+        updated_skills=updated_skills,
+        store=store,
+        emphasized_skills=[new_skill],
+        month=payload.month,
+        year=payload.year,
+        timestamp=payload.timestamp,
+    )
     return _skills_response(payload.project_id, updated_skills)

--- a/src/insights/storage.py
+++ b/src/insights/storage.py
@@ -1017,6 +1017,99 @@ class ProjectInsightsStore:
                 )
                 conn.commit()
 
+    def upsert_project_chronology_override(
+        self,
+        project_id: int,
+        timeline: List[Dict[str, Any]],
+    ) -> bool:
+        """
+        Persist a project-specific chronology override under chronology_json.project_overrides.
+
+        The override is keyed by project_info.id so chronological endpoints can return
+        timeline data that reflects user mutations from /skills endpoints.
+        """
+        with self._lock:
+            with self._connect() as conn:
+                project_row = conn.execute(
+                    f"SELECT ingest_id FROM {PROJECT_INFO_TABLE} WHERE id = ?;",
+                    (project_id,),
+                ).fetchone()
+                if not project_row:
+                    return False
+                ingest_id = int(project_row[0])
+
+                chronology_row = conn.execute(
+                    f"""
+                    SELECT id, chronology_json
+                    FROM {CHRONOLOGY_TABLE}
+                    WHERE ingest_id = ?
+                    ORDER BY id DESC
+                    LIMIT 1;
+                    """,
+                    (ingest_id,),
+                ).fetchone()
+
+                chronology_payload: Dict[str, Any] = {}
+                chronology_row_id: Optional[int] = None
+                if chronology_row:
+                    chronology_row_id = int(chronology_row[0])
+                    raw_payload = chronology_row[1]
+                    if raw_payload:
+                        try:
+                            loaded = json.loads(raw_payload)
+                            if isinstance(loaded, dict):
+                                chronology_payload = loaded
+                        except Exception:
+                            chronology_payload = {}
+
+                if not isinstance(chronology_payload.get("timeline"), list):
+                    chronology_payload["timeline"] = []
+                if not isinstance(chronology_payload.get("categories"), list):
+                    chronology_payload["categories"] = []
+                if not isinstance(chronology_payload.get("total_events"), int):
+                    chronology_payload["total_events"] = len(chronology_payload["timeline"])
+
+                overrides = chronology_payload.get("project_overrides")
+                if not isinstance(overrides, dict):
+                    overrides = {}
+                    chronology_payload["project_overrides"] = overrides
+
+                categories = sorted(
+                    {
+                        str(item.get("category"))
+                        for item in timeline
+                        if isinstance(item, dict) and isinstance(item.get("category"), str)
+                    }
+                )
+                overrides[str(project_id)] = {
+                    "timeline": timeline,
+                    "total_events": len(timeline),
+                    "categories": categories,
+                    "updated_at": _utcnow(),
+                }
+
+                now = _utcnow()
+                payload_json = json.dumps(chronology_payload)
+                if chronology_row_id is not None:
+                    conn.execute(
+                        f"""
+                        UPDATE {CHRONOLOGY_TABLE}
+                        SET chronology_json = ?, created_at = ?
+                        WHERE id = ?;
+                        """,
+                        (payload_json, now, chronology_row_id),
+                    )
+                else:
+                    conn.execute(
+                        f"""
+                        INSERT OR REPLACE INTO {CHRONOLOGY_TABLE} (ingest_id, chronology_json, created_at)
+                        VALUES (?, ?, ?);
+                        """,
+                        (ingest_id, payload_json, now),
+                    )
+                conn.commit()
+                return True
+
     def load_latest_global_insights(self) -> Optional[Dict[str, Any]]:
         """Load global insights for the latest ingest run."""
         with self._connect() as conn:

--- a/tests/api/test_skills_endpoints.py
+++ b/tests/api/test_skills_endpoints.py
@@ -161,3 +161,74 @@ def test_year_validation_422(skills_client):
     client, _ = skills_client
     response = client.get("/skills/year", params={"year": 26})
     assert response.status_code == 422
+
+
+def test_skill_mutations_persist_to_chronological_timeline(skills_client):
+    client, project_id = skills_client
+
+    add_response = client.post(
+        "/skills/add",
+        json={"project_id": project_id, "skills": ["graphql"], "month": 2, "year": 2027},
+    )
+    assert add_response.status_code == 200
+    assert "graphql" in add_response.json()["skills"]
+
+    after_add = client.get(f"/chronological/skills/{project_id}")
+    assert after_add.status_code == 200
+    add_timeline = after_add.json()["timeline"]
+    assert any("graphql" in item.get("skills", []) for item in add_timeline)
+    assert any(
+        "graphql" in item.get("skills", []) and str(item.get("timestamp", "")).startswith("2027-02-01")
+        for item in add_timeline
+    )
+
+    edit_response = client.post(
+        "/skills/edit",
+        json={"project_id": project_id, "old": "graphql", "new": "rust", "month": 3, "year": 2028},
+    )
+    assert edit_response.status_code == 200
+    assert "graphql" not in edit_response.json()["skills"]
+    assert "rust" in edit_response.json()["skills"]
+
+    after_edit = client.get(f"/chronological/skills/{project_id}")
+    assert after_edit.status_code == 200
+    edit_timeline = after_edit.json()["timeline"]
+    assert all("graphql" not in item.get("skills", []) for item in edit_timeline)
+    assert any("rust" in item.get("skills", []) for item in edit_timeline)
+    assert any(
+        "rust" in item.get("skills", []) and str(item.get("timestamp", "")).startswith("2028-03-01")
+        for item in edit_timeline
+    )
+
+    remove_response = client.post(
+        "/skills/remove",
+        json={"project_id": project_id, "skills": ["rust"]},
+    )
+    assert remove_response.status_code == 200
+    assert "rust" not in remove_response.json()["skills"]
+
+    after_remove = client.get(f"/chronological/skills/{project_id}")
+    assert after_remove.status_code == 404
+
+
+def test_month_year_must_be_provided_together(skills_client):
+    client, project_id = skills_client
+    response = client.post(
+        "/skills/add",
+        json={"project_id": project_id, "skills": ["python"], "month": 5},
+    )
+    assert response.status_code == 400
+    assert "month" in response.json()["detail"].lower()
+
+
+def test_empty_override_does_not_fallback_to_base_chronology(skills_client):
+    client, project_id = skills_client
+    clear_response = client.post(
+        "/skills/edit",
+        json={"project_id": project_id, "skills": []},
+    )
+    assert clear_response.status_code == 200
+    assert clear_response.json() == {"project_id": project_id, "skills": []}
+
+    timeline_response = client.get(f"/chronological/skills/{project_id}")
+    assert timeline_response.status_code == 404


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR makes skills mutations persist into the project chronology source so the chronological timeline stays consistent after add, edit, and remove operations. It adds optional date metadata support on skill mutation payloads, allowing updated skills to carry real timeline timing instead of only changing the skill catalog. It also extends backend test coverage for chronology synchronization, date validation, and override behavior to prevent stale timeline data from reappearing after refresh or reload.

**Closes:** #345 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [x] ⚡ Performance improvement

---

## 🧪 Testing

Start services
```
docker compose up -d --build
docker compose ps
```
Run targeted backend tests
```
docker compose run --rm backend pytest tests/api/test_skills_endpoints.py -q
```
Run full backend API tests
```
docker compose run --rm backend pytest tests/api -q
```
Manual API sanity checks (optional)
```
# Add a skill with date metadata
curl -sS -X POST http://localhost:8000/skills/add \
  -H "Content-Type: application/json" \
  -d '{"project_id":1,"skills":["TypeScript"],"month":3,"year":2026}'

# Verify chronology for that project reflects mutation
curl -sS http://localhost:8000/chronological/skills/1
```
Teardown when done
```
docker compose down
```
---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
