### PR TITLE
Feature for user to generate web portfolio

### DIFF
--- a/frontend/src/renderer/src/App.tsx
+++ b/frontend/src/renderer/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { filterProjects, generateResumePdf, type FilteredProject, type ResumeEducationInput } from './api'
+import { filterProjects, generateResumePdf, generatePortfolioSite, type FilteredProject, type ResumeEducationInput } from './api'
 import { StatsCards } from './components/StatsCards'
 import { UploadZone } from './components/UploadZone'
 import { FilterTabs, type TabKey } from './components/FilterTabs'
@@ -156,6 +156,21 @@ function App() {
   const [timelineRefreshNonce, setTimelineRefreshNonce] = useState(0)
   const [timelineBusy, setTimelineBusy] = useState(false)
 
+  const [portfolioModalOpen, setPortfolioModalOpen] = useState(false)
+  const [portfolioProjectIds, setPortfolioProjectIds] = useState<number[]>([])
+  const [portfolioName, setPortfolioName] = useState('')
+  const [portfolioTitle, setPortfolioTitle] = useState('Full-Stack Developer')
+  const [portfolioBio, setPortfolioBio] = useState('')
+  const [portfolioEmail, setPortfolioEmail] = useState('')
+  const [portfolioLocation, setPortfolioLocation] = useState('')
+  const [portfolioGithubUrl, setPortfolioGithubUrl] = useState('')
+  const [portfolioLinkedinUrl, setPortfolioLinkedinUrl] = useState('')
+  const [portfolioYoe, setPortfolioYoe] = useState('')
+  const [portfolioOss, setPortfolioOss] = useState('')
+  const [portfolioGenerating, setPortfolioGenerating] = useState(false)
+  const [portfolioError, setPortfolioError] = useState('')
+  const [portfolioUrl, setPortfolioUrl] = useState<string | null>(null)
+
   const loadProjects = useCallback(async () => {
     setLoading(true)
     try {
@@ -299,6 +314,76 @@ function App() {
   const removeEducationEntry = useCallback((index: number) => {
     setResumeEducation((prev) => (prev.length === 1 ? [blankEducation()] : prev.filter((_, currentIndex) => currentIndex !== index)))
   }, [])
+
+  const resetPortfolioModal = useCallback(() => {
+    setPortfolioModalOpen(false)
+    setPortfolioProjectIds([])
+    setPortfolioName('')
+    setPortfolioTitle('Full-Stack Developer')
+    setPortfolioBio('')
+    setPortfolioEmail('')
+    setPortfolioLocation('')
+    setPortfolioGithubUrl('')
+    setPortfolioLinkedinUrl('')
+    setPortfolioYoe('')
+    setPortfolioOss('')
+    setPortfolioError('')
+    setPortfolioGenerating(false)
+    setPortfolioUrl(null)
+  }, [])
+
+  const handlePortfolioCardClick = useCallback(() => {
+    setPortfolioError('')
+    if (projects.length === 0) {
+      addToast('No projects available', 'error', 'Upload and analyze a ZIP before generating a portfolio.')
+      setView('upload')
+      return
+    }
+    setPortfolioProjectIds((prev) => (prev.length > 0 ? prev : projects.slice(0, 2).map((p) => p.project_info_id)))
+    setPortfolioModalOpen(true)
+  }, [addToast, projects])
+
+  const togglePortfolioProject = useCallback((projectId: number) => {
+    setPortfolioProjectIds((prev) =>
+      prev.includes(projectId)
+        ? prev.filter((id) => id !== projectId)
+        : prev.length >= 4 ? prev : [...prev, projectId],
+    )
+  }, [])
+
+  const handleGeneratePortfolio = useCallback(async () => {
+    if (portfolioProjectIds.length < 2) {
+      setPortfolioError('Select at least 2 projects.')
+      return
+    }
+    if (!portfolioName.trim()) {
+      setPortfolioError('Enter your name.')
+      return
+    }
+    setPortfolioGenerating(true)
+    setPortfolioError('')
+    try {
+      const res = await generatePortfolioSite({
+        name: portfolioName.trim(),
+        title: portfolioTitle.trim() || 'Full-Stack Developer',
+        bio: portfolioBio.trim(),
+        email: portfolioEmail.trim(),
+        location: portfolioLocation.trim(),
+        github_url: portfolioGithubUrl.trim(),
+        linkedin_url: portfolioLinkedinUrl.trim(),
+        years_experience: portfolioYoe.trim(),
+        projects_completed: String(projects.length),
+        open_source_contributions: portfolioOss.trim(),
+        project_ids: portfolioProjectIds,
+      })
+      setPortfolioUrl(res.url)
+      addToast('Portfolio ready', 'success', res.message || 'Your portfolio is live at localhost:3000')
+    } catch (e) {
+      setPortfolioError(e instanceof Error ? e.message : 'Failed to generate portfolio')
+    } finally {
+      setPortfolioGenerating(false)
+    }
+  }, [addToast, portfolioBio, portfolioEmail, portfolioGithubUrl, portfolioLinkedinUrl, portfolioLocation, portfolioName, portfolioOss, portfolioProjectIds, portfolioTitle, portfolioYoe, projects.length])
 
   const filteredProjects = useMemo(() => {
     let list = projects
@@ -481,10 +566,15 @@ function App() {
                             }
                             if (card.id === 'resume') {
                               handleResumeCardClick()
+                              return
+                            }
+                            if (card.id === 'portfolio') {
+                              handlePortfolioCardClick()
+                              return
                             }
                           }}
                         >
-                          {card.id === 'timeline' ? 'Open Timeline' : card.id === 'resume' ? 'Generate Resume' : 'Customize'}
+                          {card.id === 'timeline' ? 'Open Timeline' : card.id === 'resume' ? 'Generate Resume' : card.id === 'portfolio' ? 'Generate Portfolio' : 'Customize'}
                         </button>
                       </article>
                     ))
@@ -760,6 +850,134 @@ function App() {
                 disabled={resumeGenerating}
               >
                 {resumeGenerating ? 'Generating…' : 'Generate PDF'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {portfolioModalOpen && (
+        <div className="skill-modal" role="dialog" aria-modal="true" aria-labelledby="portfolio-modal-title">
+          <div className="modal-content">
+            <button className="close" onClick={resetPortfolioModal} aria-label="Close">
+              ×
+            </button>
+            <div className="modal-header">
+              <h2 id="portfolio-modal-title">Generate Web Portfolio</h2>
+              <span className="modal-category">Portfolio</span>
+            </div>
+
+            <p className="modal-description">
+              Select 2–4 projects, fill in your profile details, then generate your portfolio website.
+            </p>
+
+            <div className="modal-section">
+              <h4>Projects (select 2–4)</h4>
+              <div style={{ display: 'grid', gap: 8, maxHeight: 180, overflowY: 'auto' }}>
+                {projects.map((project) => (
+                  <label
+                    key={project.project_info_id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 10,
+                      padding: '10px 12px',
+                      border: '1px solid var(--border)',
+                      borderRadius: 10,
+                      background: 'var(--bg-secondary)',
+                      opacity: !portfolioProjectIds.includes(project.project_info_id) && portfolioProjectIds.length >= 4 ? 0.5 : 1,
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={portfolioProjectIds.includes(project.project_info_id)}
+                      onChange={() => togglePortfolioProject(project.project_info_id)}
+                      disabled={!portfolioProjectIds.includes(project.project_info_id) && portfolioProjectIds.length >= 4}
+                    />
+                    <span>{project.project_name}</span>
+                  </label>
+                ))}
+              </div>
+              <span style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4, display: 'block' }}>
+                {portfolioProjectIds.length}/4 selected
+              </span>
+            </div>
+
+            <div className="modal-section">
+              <h4>Name</h4>
+              <input
+                className="input"
+                type="text"
+                placeholder="e.g. Jane Doe"
+                value={portfolioName}
+                onChange={(e) => setPortfolioName(e.target.value)}
+                style={{ width: '100%', minWidth: 0 }}
+              />
+            </div>
+
+            <div className="modal-section">
+              <h4>Title</h4>
+              <input
+                className="input"
+                type="text"
+                placeholder="e.g. Full-Stack Developer"
+                value={portfolioTitle}
+                onChange={(e) => setPortfolioTitle(e.target.value)}
+                style={{ width: '100%', minWidth: 0 }}
+              />
+            </div>
+
+            <div className="modal-section">
+              <h4>About Me</h4>
+              <textarea
+                className="input"
+                placeholder="Write a short bio about yourself..."
+                value={portfolioBio}
+                onChange={(e) => setPortfolioBio(e.target.value)}
+                rows={3}
+                style={{ width: '100%', minWidth: 0, resize: 'vertical' }}
+              />
+            </div>
+
+            <div className="modal-section">
+              <h4>Contact & Links</h4>
+              <div style={{ display: 'grid', gap: 10 }}>
+                <input className="input" type="email" placeholder="Email address" value={portfolioEmail} onChange={(e) => setPortfolioEmail(e.target.value)} style={{ width: '100%', minWidth: 0 }} />
+                <input className="input" type="text" placeholder="Location (e.g. Vancouver, BC)" value={portfolioLocation} onChange={(e) => setPortfolioLocation(e.target.value)} style={{ width: '100%', minWidth: 0 }} />
+                <input className="input" type="text" placeholder="GitHub URL" value={portfolioGithubUrl} onChange={(e) => setPortfolioGithubUrl(e.target.value)} style={{ width: '100%', minWidth: 0 }} />
+                <input className="input" type="text" placeholder="LinkedIn URL" value={portfolioLinkedinUrl} onChange={(e) => setPortfolioLinkedinUrl(e.target.value)} style={{ width: '100%', minWidth: 0 }} />
+              </div>
+            </div>
+
+            <div className="modal-section">
+              <h4>Highlights</h4>
+              <div style={{ display: 'grid', gap: 10 }}>
+                <input className="input" type="text" placeholder="Years of experience (e.g. 4+)" value={portfolioYoe} onChange={(e) => setPortfolioYoe(e.target.value)} style={{ width: '100%', minWidth: 0 }} />
+                <input className="input" type="text" placeholder="Open source contributions (e.g. 50+)" value={portfolioOss} onChange={(e) => setPortfolioOss(e.target.value)} style={{ width: '100%', minWidth: 0 }} />
+              </div>
+            </div>
+
+            {portfolioError && (
+              <p className="filter-error" style={{ marginBottom: 12 }}>{portfolioError}</p>
+            )}
+
+            <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
+              {portfolioUrl && (
+                <a
+                  className="btn-primary"
+                  href={portfolioUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View Portfolio
+                </a>
+              )}
+              <button
+                className="btn-primary"
+                onClick={handleGeneratePortfolio}
+                disabled={portfolioGenerating}
+              >
+                {portfolioGenerating ? 'Generating…' : 'Generate Portfolio'}
               </button>
             </div>
           </div>

--- a/frontend/src/renderer/src/api.ts
+++ b/frontend/src/renderer/src/api.ts
@@ -253,6 +253,27 @@ export type ResumePdfRequest = {
   education?: ResumeEducationInput[]
 }
 
+export type PortfolioSiteRequest = {
+  name: string
+  title?: string
+  bio?: string
+  email?: string
+  location?: string
+  github_url?: string
+  linkedin_url?: string
+  years_experience?: string
+  projects_completed?: string
+  open_source_contributions?: string
+  project_ids: number[]
+}
+
+export type PortfolioSiteResponse = {
+  status: string
+  url: string
+  server_started: boolean
+  message: string
+}
+
 // ─── API Functions ─────────────────────────────────────────────────
 
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
@@ -340,6 +361,14 @@ export async function getPortfolio(projectId: number): Promise<PortfolioData> {
     },
     evolution: raw.evolution as PortfolioData['evolution'],
   }
+}
+
+export function generatePortfolioSite(payload: PortfolioSiteRequest): Promise<PortfolioSiteResponse> {
+  return apiFetch('/portfolio/generate-site', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
 }
 
 // Resume

--- a/portfolio-template/src/config/portfolio.ts
+++ b/portfolio-template/src/config/portfolio.ts
@@ -1,121 +1,61 @@
 import type { DeveloperProfile } from "@/types/portfolio";
 
 export const portfolio: DeveloperProfile = {
-  name: "Alex Chen",
-  title: "Full-Stack Developer",
-  bio: "I build polished, accessible web experiences with modern tools. Currently focused on design systems and developer tooling.",
+  name: "Kaiden Merchant",
+  title: "Software Engineer",
+  bio: "I am a Software Engineer dedicated to building scalable, user-centric applications that solve real-world problems. With a core focus on Python and React, I enjoy bridging the gap between complex backend logic and seamless frontend experiences. I thrive in collaborative environments where clean code, architectural integrity, and efficient performance are the standard.",
   avatarUrl: "/avatar-placeholder.jpg",
   resumeUrl: "/resume.pdf",
-  email: "alex@example.com",
-  location: "Vancouver, BC",
+  email: "kaiden@gmail.com",
+  location: "Kelowna, BC",
 
   socials: [
-    { platform: "GitHub", url: "https://github.com", icon: "github" },
-    { platform: "LinkedIn", url: "https://linkedin.com", icon: "linkedin" },
-    { platform: "Twitter", url: "https://twitter.com", icon: "twitter" },
+    { platform: "GitHub", url: "kaiden@github.com", icon: "github" },
+    { platform: "LinkedIn", url: "kaiden@linkedin.com", icon: "linkedin" }
   ],
 
   about: {
     description: [
-      "I'm a full-stack developer with a passion for building clean, performant web applications. With experience across the entire stack, I enjoy turning complex problems into simple, elegant solutions.",
-      "When I'm not coding, you can find me contributing to open-source projects, writing technical blog posts, or exploring the outdoors.",
+      "I am a Software Engineer dedicated to building scalable, user-centric applications that solve real-world problems. With a core focus on Python and React, I enjoy bridging the gap between complex backend logic and seamless frontend experiences. I thrive in collaborative environments where clean code, architectural integrity, and efficient performance are the standard."
     ],
     highlights: [
-      { label: "Years Experience", value: "4+" },
-      { label: "Projects Completed", value: "20+" },
-      { label: "Open Source Contributions", value: "50+" },
+      { label: "Years Experience", value: "2" },
+      { label: "Projects Completed", value: "100" },
+      { label: "Open Source Contributions", value: "1" }
     ],
   },
 
   skills: [
     {
       name: "Languages",
-      skills: ["TypeScript", "Python", "JavaScript", "Go", "SQL"],
+      skills: ["java", "python"],
     },
     {
-      name: "Frontend",
-      skills: ["React", "Next.js", "Tailwind CSS", "Framer Motion"],
+      name: "Tools & Skills",
+      skills: ["java", "numpy", "object-oriented-programming", "pandas", "python"],
     },
     {
-      name: "Backend",
-      skills: ["Node.js", "FastAPI", "PostgreSQL", "Redis"],
-    },
-    {
-      name: "Tools",
-      skills: ["Git", "Docker", "Figma", "Vercel", "AWS"],
-    },
+      name: "Frameworks",
+      skills: ["numpy", "pandas"],
+    }
   ],
 
   projects: [
     {
-      title: "DevBoard",
-      description:
-        "A real-time project management dashboard built for developer teams. Features Kanban boards, sprint tracking, and GitHub integration.",
+      title: "project1",
+      description: "A comprehensive project comprising 2 source files and 13 lines of code.",
       image: "/placeholder-project.jpg",
-      tags: ["Next.js", "TypeScript", "Prisma", "WebSockets"],
-      liveUrl: "https://example.com",
-      sourceUrl: "https://github.com",
+      tags: ["java", "python"],
       featured: true,
     },
     {
-      title: "Synthwave UI",
-      description:
-        "An open-source component library with a retro-futuristic aesthetic. Fully accessible and tree-shakeable.",
+      title: "ml-recommendation-engine",
+      description: "A comprehensive project comprising 1 source file and 211 lines of code.",
       image: "/placeholder-project.jpg",
-      tags: ["React", "Storybook", "Radix UI", "CSS"],
-      sourceUrl: "https://github.com",
+      tags: ["python", "numpy", "pandas", "object-oriented-programming"],
       featured: true,
-    },
-    {
-      title: "CloudCast",
-      description:
-        "A weather application with hyper-local forecasts, interactive radar maps, and severe weather alerts.",
-      image: "/placeholder-project.jpg",
-      tags: ["React Native", "GraphQL", "Mapbox"],
-      liveUrl: "https://example.com",
-    },
-    {
-      title: "Terracotta",
-      description:
-        "A CLI tool for scaffolding full-stack applications with pre-configured auth, database, and deployment pipelines.",
-      image: "/placeholder-project.jpg",
-      tags: ["Go", "Cobra", "Docker", "PostgreSQL"],
-      sourceUrl: "https://github.com",
-    },
+    }
   ],
 
-  experience: [
-    {
-      company: "Nexus Technologies",
-      role: "Software Engineer",
-      startDate: "Jan 2024",
-      endDate: "Present",
-      description: [
-        "Led the rebuild of the customer-facing dashboard, improving load times by 40%.",
-        "Designed and shipped a component library adopted by 3 product teams.",
-        "Mentored 2 junior developers through onboarding and code reviews.",
-      ],
-    },
-    {
-      company: "Bright Studio",
-      role: "Frontend Developer",
-      startDate: "Jun 2022",
-      endDate: "Dec 2023",
-      description: [
-        "Built responsive marketing pages and product landing sites for clients.",
-        "Integrated headless CMS solutions reducing content update turnaround by 60%.",
-        "Implemented analytics tracking and A/B testing infrastructure.",
-      ],
-    },
-    {
-      company: "Open Source",
-      role: "Contributor",
-      startDate: "2021",
-      endDate: "Present",
-      description: [
-        "Active contributor to several popular React and TypeScript libraries.",
-        "Authored and maintained a CSS utility library with 500+ GitHub stars.",
-      ],
-    },
-  ],
+  experience: [],
 };

--- a/src/api/routers/portfolio.py
+++ b/src/api/routers/portfolio.py
@@ -3,11 +3,17 @@ Portfolio API router.
 
 Provides GET /portfolio/{project_id} with optional ?template=industry or ?template=academic
 to tailor the response for professional (impact, deliverables) vs academic (rigor, artifacts)
-contexts. Also supports edit, generate, and template listing endpoints.
+contexts. Also supports edit, generate, template listing, and site generation endpoints.
 """
 from __future__ import annotations
 
 import datetime
+import json
+import logging
+import os
+import shutil
+import signal
+import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
 
@@ -18,6 +24,8 @@ from src.api.deps import get_role_store, get_store
 from src.insights.storage import ProjectInsightsStore
 from src.insights.user_role_store import ProjectRoleStore
 from src.pipeline.presentation_pipeline import PresentationPipeline
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/portfolio", tags=["portfolio"])
 
@@ -596,3 +604,257 @@ def generate_portfolio(project_id: int, store: ProjectInsightsStore = Depends(ge
     if persist_fields:
         store.update_portfolio_insights_fields(project_id, persist_fields)
     return {"project_id": project_id, "portfolio_item": portfolio}
+
+
+# ---------------------------------------------------------------------------
+# Portfolio site generation
+# ---------------------------------------------------------------------------
+
+_portfolio_dev_pid: Optional[int] = None
+
+PORTFOLIO_TEMPLATE_DIR = Path(__file__).resolve().parents[3] / "portfolio-template"
+
+
+class PortfolioSiteRequest(BaseModel):
+    name: str
+    title: str = "Full-Stack Developer"
+    bio: str = ""
+    email: str = ""
+    location: str = ""
+    github_url: str = ""
+    linkedin_url: str = ""
+    years_experience: str = ""
+    projects_completed: str = ""
+    open_source_contributions: str = ""
+    project_ids: List[int] = Field(..., min_length=2, max_length=4)
+
+
+def _build_portfolio_ts(profile: Dict[str, Any]) -> str:
+    """Render a syntactically valid TypeScript config from the profile dict."""
+
+    def _js(value: Any) -> str:
+        return json.dumps(value, ensure_ascii=False)
+
+    socials = profile.get("socials") or []
+    about = profile.get("about") or {}
+    skills = profile.get("skills") or []
+    projects = profile.get("projects") or []
+
+    socials_str = ",\n    ".join(
+        f'{{ platform: {_js(s["platform"])}, url: {_js(s["url"])}, icon: {_js(s["icon"])} }}'
+        for s in socials
+    )
+
+    highlights_str = ",\n      ".join(
+        f'{{ label: {_js(h["label"])}, value: {_js(h["value"])} }}'
+        for h in (about.get("highlights") or [])
+    )
+
+    desc_str = ",\n      ".join(_js(d) for d in (about.get("description") or []))
+
+    skill_cats = []
+    for cat in skills:
+        items = ", ".join(_js(s) for s in cat["skills"])
+        skill_cats.append(
+            f'    {{\n      name: {_js(cat["name"])},\n      skills: [{items}],\n    }}'
+        )
+    skills_str = ",\n".join(skill_cats)
+
+    proj_entries = []
+    for p in projects:
+        tags = ", ".join(_js(t) for t in p.get("tags", []))
+        entry = f'    {{\n      title: {_js(p["title"])},\n      description: {_js(p.get("description", ""))},\n      image: "/placeholder-project.jpg",\n      tags: [{tags}],'
+        if p.get("sourceUrl"):
+            entry += f'\n      sourceUrl: {_js(p["sourceUrl"])},'
+        if p.get("liveUrl"):
+            entry += f'\n      liveUrl: {_js(p["liveUrl"])},'
+        if p.get("featured"):
+            entry += "\n      featured: true,"
+        entry += "\n    }"
+        proj_entries.append(entry)
+    projects_str = ",\n".join(proj_entries)
+
+    return f'''import type {{ DeveloperProfile }} from "@/types/portfolio";
+
+export const portfolio: DeveloperProfile = {{
+  name: {_js(profile.get("name", ""))},
+  title: {_js(profile.get("title", ""))},
+  bio: {_js(profile.get("bio", ""))},
+  avatarUrl: "/avatar-placeholder.jpg",
+  resumeUrl: "/resume.pdf",
+  email: {_js(profile.get("email", ""))},
+  location: {_js(profile.get("location", ""))},
+
+  socials: [
+    {socials_str}
+  ],
+
+  about: {{
+    description: [
+      {desc_str}
+    ],
+    highlights: [
+      {highlights_str}
+    ],
+  }},
+
+  skills: [
+{skills_str}
+  ],
+
+  projects: [
+{projects_str}
+  ],
+
+  experience: [],
+}};
+'''
+
+
+def _is_running_in_docker() -> bool:
+    """Detect if the process is running inside a Docker container."""
+    return os.path.exists("/.dockerenv") or os.environ.get("RUNNING_IN_DOCKER") == "1"
+
+
+def _find_npm() -> Optional[str]:
+    """Return the path to npm if available, or None."""
+    return shutil.which("npm")
+
+
+def _ensure_dev_server() -> bool:
+    """Start the Next.js dev server if it is not already running.
+
+    Returns True if the server was started or is already running,
+    False if npm is unavailable (e.g. inside Docker).
+    """
+    global _portfolio_dev_pid
+
+    if _portfolio_dev_pid is not None:
+        try:
+            os.kill(_portfolio_dev_pid, 0)
+            return True
+        except OSError:
+            _portfolio_dev_pid = None
+
+    if _is_running_in_docker():
+        logger.info("Running inside Docker — skipping portfolio dev server (run 'npm run dev' in portfolio-template/ on the host)")
+        return False
+
+    npm_path = _find_npm()
+    if not npm_path:
+        logger.warning("npm not found — cannot start portfolio dev server")
+        return False
+
+    proc = subprocess.Popen(
+        [npm_path, "run", "dev"],
+        cwd=str(PORTFOLIO_TEMPLATE_DIR),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    _portfolio_dev_pid = proc.pid
+    logger.info("Started portfolio dev server (pid=%s)", proc.pid)
+    return True
+
+
+@router.post("/generate-site")
+def generate_portfolio_site(
+    req: PortfolioSiteRequest,
+    store: ProjectInsightsStore = Depends(get_store),
+):
+    """
+    Generate a portfolio website from user profile info and selected projects.
+
+    Writes the portfolio config, starts the Next.js dev server, and returns
+    the URL where the user can view their portfolio.
+    """
+    socials: List[Dict[str, str]] = []
+    if req.github_url:
+        socials.append({"platform": "GitHub", "url": req.github_url, "icon": "github"})
+    if req.linkedin_url:
+        socials.append({"platform": "LinkedIn", "url": req.linkedin_url, "icon": "linkedin"})
+
+    highlights: List[Dict[str, str]] = []
+    if req.years_experience:
+        highlights.append({"label": "Years Experience", "value": req.years_experience})
+    if req.projects_completed:
+        highlights.append({"label": "Projects Completed", "value": req.projects_completed})
+    if req.open_source_contributions:
+        highlights.append({"label": "Open Source Contributions", "value": req.open_source_contributions})
+
+    all_skills: Dict[str, set] = {}
+    ts_projects: List[Dict[str, Any]] = []
+
+    for i, pid in enumerate(req.project_ids):
+        payload = store.load_project_insight_by_id(pid)
+        if payload is None:
+            raise HTTPException(status_code=404, detail=f"Project {pid} not found")
+
+        portfolio_item = payload.get("portfolio_item") or {}
+        project_metrics = payload.get("project_metrics") or {}
+        project_name = payload.get("project_name") or f"Project {pid}"
+
+        skills_list = (
+            portfolio_item.get("skills")
+            or project_metrics.get("skills")
+            or []
+        )
+        languages = portfolio_item.get("languages") or project_metrics.get("languages") or []
+        frameworks = portfolio_item.get("frameworks") or project_metrics.get("frameworks") or []
+
+        for lang in languages:
+            all_skills.setdefault("Languages", set()).add(str(lang))
+        for fw in frameworks:
+            all_skills.setdefault("Frameworks", set()).add(str(fw))
+        for sk in skills_list:
+            all_skills.setdefault("Tools & Skills", set()).add(str(sk))
+
+        tags = list(dict.fromkeys(
+            [str(s) for s in languages[:3]] + [str(s) for s in frameworks[:3]] + [str(s) for s in skills_list[:3]]
+        ))
+
+        ts_projects.append({
+            "title": project_name,
+            "description": portfolio_item.get("summary") or portfolio_item.get("description") or "",
+            "tags": tags[:6],
+            "featured": i < 2,
+        })
+
+    skill_categories = [
+        {"name": cat, "skills": sorted(items)}
+        for cat, items in all_skills.items()
+        if items
+    ]
+
+    profile: Dict[str, Any] = {
+        "name": req.name,
+        "title": req.title,
+        "bio": req.bio,
+        "email": req.email,
+        "location": req.location,
+        "socials": socials,
+        "about": {
+            "description": [req.bio] if req.bio else [],
+            "highlights": highlights,
+        },
+        "skills": skill_categories,
+        "projects": ts_projects,
+    }
+
+    config_path = PORTFOLIO_TEMPLATE_DIR / "src" / "config" / "portfolio.ts"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(_build_portfolio_ts(profile), encoding="utf-8")
+    logger.info("Wrote portfolio config to %s", config_path)
+
+    server_running = _ensure_dev_server()
+
+    return {
+        "status": "ok",
+        "url": "http://localhost:3000",
+        "server_started": server_running,
+        "message": (
+            "Portfolio generated. Visit http://localhost:3000 to view it."
+            if server_running
+            else "Portfolio config written. Run 'cd portfolio-template && npm run dev' on the host to view it at http://localhost:3000."
+        ),
+    }


### PR DESCRIPTION
## 📝 Description

This PR includes work to allow the user to click "generate portfolio" and create a portfolio website with some information that is filled in -- just like how the generate resume option works.

**Closes:** #358 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

1. Click on generate portfolio
2. Fill out required info fields
3. start localhost server:
```bash
cd portfolio-template/
npm run dev
```
4. View http://localhost:3000/ and verify the website was generated properly

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

<img width="583" height="745" alt="Screenshot 2026-03-17 at 4 50 51 PM" src="https://github.com/user-attachments/assets/9cf0745b-7775-4e20-972b-d1777a0bb7f5" />

<img width="1240" height="495" alt="Screenshot 2026-03-17 at 4 51 39 PM" src="https://github.com/user-attachments/assets/b1dd20d1-f9db-4451-8fa6-d80ccd5e1d96" />




