### PR TITLE
Fixed Drag/drop into the upload zone.

### DIFF
--- a/frontend/src/main/index.ts
+++ b/frontend/src/main/index.ts
@@ -63,6 +63,24 @@ ipcMain.handle('prepare-zip-for-upload', async (_event, filePath: string) => {
   return copyToUploads(filePath)
 })
 
+// Persist dropped zip bytes when Electron cannot provide File.path.
+ipcMain.handle(
+  'prepare-dropped-zip-for-upload',
+  async (_event, payload: { fileName?: string; bytes?: Uint8Array | number[] }) => {
+    const fileName = String(payload?.fileName || '').trim()
+    const lowered = fileName.toLowerCase()
+    if (!fileName || !lowered.endsWith('.zip')) return null
+
+    const rawBytes = payload?.bytes
+    if (!rawBytes) return null
+
+    const bytes = rawBytes instanceof Uint8Array ? rawBytes : Uint8Array.from(rawBytes)
+    if (bytes.length === 0) return null
+
+    return copyBytesToUploads(fileName, bytes)
+  },
+)
+
 function copyToUploads(srcPath: string): { containerPath: string; fileName: string } {
   const uploadsDir = getUploadsDir()
   const baseName = path.basename(srcPath)
@@ -71,6 +89,15 @@ function copyToUploads(srcPath: string): { containerPath: string; fileName: stri
   const destPath = path.join(uploadsDir, destName)
   fs.copyFileSync(srcPath, destPath)
   // The Docker container sees this as /uploads/<file>
+  return { containerPath: `/uploads/${destName}`, fileName: baseName }
+}
+
+function copyBytesToUploads(fileName: string, bytes: Uint8Array): { containerPath: string; fileName: string } {
+  const uploadsDir = getUploadsDir()
+  const baseName = path.basename(fileName)
+  const destName = `${Date.now()}_${baseName}`
+  const destPath = path.join(uploadsDir, destName)
+  fs.writeFileSync(destPath, Buffer.from(bytes))
   return { containerPath: `/uploads/${destName}`, fileName: baseName }
 }
 

--- a/frontend/src/preload/index.ts
+++ b/frontend/src/preload/index.ts
@@ -8,5 +8,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     filePath: string,
   ): Promise<{ containerPath: string; fileName: string } | null> =>
     ipcRenderer.invoke('prepare-zip-for-upload', filePath),
+  prepareDroppedZipForUpload: (
+    fileName: string,
+    bytes: Uint8Array,
+  ): Promise<{ containerPath: string; fileName: string } | null> =>
+    ipcRenderer.invoke('prepare-dropped-zip-for-upload', { fileName, bytes }),
   platform: process.platform,
 })

--- a/frontend/src/renderer/src/components/UploadZone.tsx
+++ b/frontend/src/renderer/src/components/UploadZone.tsx
@@ -13,6 +13,10 @@ declare global {
       prepareZipForUpload: (
         filePath: string,
       ) => Promise<{ containerPath: string; fileName: string } | null>
+      prepareDroppedZipForUpload: (
+        fileName: string,
+        bytes: Uint8Array,
+      ) => Promise<{ containerPath: string; fileName: string } | null>
       platform: string
     }
   }
@@ -58,27 +62,36 @@ export function UploadZone({
       setDragging(false)
       const file = e.dataTransfer.files[0]
       if (!file) return
-      if (!file.name.endsWith('.zip')) {
+      if (!file.name.toLowerCase().endsWith('.zip')) {
         setErrorMsg('Only .zip files are accepted.')
         setStep('error')
         return
       }
       const filePath = (file as File & { path?: string }).path
-      if (!filePath) {
-        setErrorMsg('Could not read file path. Please use the "Select ZIP File" button instead.')
-        setStep('error')
-        return
-      }
       try {
-        if (window.electronAPI?.prepareZipForUpload) {
+        if (filePath && window.electronAPI?.prepareZipForUpload) {
           const res = await window.electronAPI.prepareZipForUpload(filePath)
           if (res) pickFile(res.containerPath, res.fileName)
           else {
             setErrorMsg('Failed to prepare file for upload. The file may not exist or is inaccessible.')
             setStep('error')
           }
-        } else {
+        } else if (window.electronAPI?.prepareDroppedZipForUpload) {
+          const buf = await file.arrayBuffer()
+          const res = await window.electronAPI.prepareDroppedZipForUpload(
+            file.name,
+            new Uint8Array(buf),
+          )
+          if (res) pickFile(res.containerPath, res.fileName)
+          else {
+            setErrorMsg('Failed to prepare dropped file for upload.')
+            setStep('error')
+          }
+        } else if (filePath) {
           pickFile(filePath, file.name)
+        } else {
+          setErrorMsg('File upload requires the desktop app. Please run the Electron application.')
+          setStep('error')
         }
       } catch (err) {
         setErrorMsg(err instanceof Error ? err.message : 'Failed to prepare file')
@@ -108,7 +121,7 @@ export function UploadZone({
     async (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0]
       if (!file) return
-      if (!file.name.endsWith('.zip')) {
+      if (!file.name.toLowerCase().endsWith('.zip')) {
         setErrorMsg('Only .zip files are accepted.')
         setStep('error')
         e.target.value = ''


### PR DESCRIPTION
## 📝 Description

This PR fixes the bug where the user cannot drop a zip file into the upload zone.

**Closes:** #383 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manual Testing

1. Go to upload tab
2. Drag/drop a zip file into the upload zone
3. Start analysis

---
